### PR TITLE
Added exception handling in hash() method

### DIFF
--- a/duplicateimagefinder/app.py
+++ b/duplicateimagefinder/app.py
@@ -106,7 +106,11 @@ class ImageUtils(object):
                 image = Image.open(image)
             except IOError:
                 return None
-        image = image.resize((8, 9), Image.ANTIALIAS).convert('L')
+        try:
+            image = image.resize((8, 9), Image.ANTIALIAS).convert('L')
+        except (IOError,SyntaxError) as e:
+            print("Error reading file " + str(filename) + ": " + str(e))
+            return None
         avg = reduce(lambda x, y: x + y, image.getdata()) / 64.
         avhash = reduce(lambda x, (y, z): x | (z << y),
                         enumerate(map(lambda i: 0 if i < avg else 1, image.getdata())),


### PR DESCRIPTION
This avoids crashing with errors like "image file is truncated" when there are corrupted images. Instead it just prints the error.